### PR TITLE
Add custom command support for Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ You can have Chassis automatically run custom commands in a number of directorie
 yarn:
     paths:
         - path: /vagrant/content/plugins/yourplugin
-		  command: 'yarn install && yarn compile"
+          command: 'yarn install && yarn compile"
         - /vagrant/content/themes/atheme
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ You can have Chassis automatically run custom commands in a number of directorie
 yarn:
     paths:
         - path: /vagrant/content/plugins/yourplugin
-          command: 'yarn install && yarn compile"
+          command: 'yarn install && yarn compile'
         - /vagrant/content/themes/atheme
 ```

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ yarn:
 ```
 
 You'll need to run `vagrant provision` for those to be installed if you'd added them after your first initial Chassis `vagrant up`.
+
+## Custom yarn command
+
+You can have Chassis automatically run custom commands in a number of directories in your project by adding a list of directories in one of your [yaml](http://docs.chassis.io/en/latest/config/) files. e.g.
+```
+yarn:
+    paths:
+        - path: /vagrant/content/plugins/yourplugin
+		  command: 'yarn install && yarn compile"
+        - /vagrant/content/themes/atheme
+```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ yarn:
 
 You'll need to run `vagrant provision` for those to be installed if you'd added them after your first initial Chassis `vagrant up`.
 
-## Custom yarn command
+## Custom Yarn commands
 
 You can have Chassis automatically run custom commands in a number of directories in your project by adding a list of directories in one of your [yaml](http://docs.chassis.io/en/latest/config/) files. e.g.
 ```

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -25,7 +25,7 @@ class yarn (
 # Puppet 3.8 doesn't have the .each function and we need an alternative.
 define install_yarn {
   if is_hash($name) {
-    exec { "Executing ${name[command]}":
+    exec { "Executing ${name[command]} in ${name[path]}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name[path],
       command   => $name[command],
@@ -33,7 +33,7 @@ define install_yarn {
       logoutput => true
     }
   } else {
-    exec { "Installing yarn ${name}":
+    exec { "Running yarn install in ${name}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name,
       command   => 'yarn install',

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -24,11 +24,21 @@ class yarn (
 
 # Puppet 3.8 doesn't have the .each function and we need an alternative.
 define install_yarn {
-	exec { "Installing yarn ${name}":
-		path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
-		cwd       => $name,
-		command   => 'yarn install',
-		require   => [ Exec['install yarn'] ],
-		logoutput => true
-	}
+  if is_hash($name) {
+    exec { "Executing yarn ${name[command]}":
+      path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
+      cwd       => $name[path],
+      command   => "yarn ${name[command]}",
+      require   => [ Exec['install yarn'] ],
+      logoutput => true
+    }
+  } else {
+    exec { "Installing yarn ${name}":
+      path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
+      cwd       => $name,
+      command   => 'yarn install',
+      require   => [ Exec['install yarn'] ],
+      logoutput => true
+    }
+  }
 }

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -25,7 +25,7 @@ class yarn (
 # Puppet 3.8 doesn't have the .each function and we need an alternative.
 define install_yarn {
   if is_hash($name) {
-    exec { "Executing yarn ${name[command]}":
+    exec { "Executing ${name[command]}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name[path],
       command   => $name[command],

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -25,7 +25,7 @@ class yarn (
 # Puppet 3.8 doesn't have the .each function and we need an alternative.
 define install_yarn {
   if is_hash($name) {
-    exec { "Executing ${name[command]} in ${name[path]}":
+    exec { "Executing: ${name[command]} in ${name[path]}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name[path],
       command   => $name[command],
@@ -33,7 +33,7 @@ define install_yarn {
       logoutput => true
     }
   } else {
-    exec { "Running yarn install in ${name}":
+    exec { "Executing: yarn install in ${name}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name,
       command   => 'yarn install',

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -28,7 +28,7 @@ define install_yarn {
     exec { "Executing yarn ${name[command]}":
       path      => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
       cwd       => $name[path],
-      command   => "yarn ${name[command]}",
+      command   => $name[command],
       require   => [ Exec['install yarn'] ],
       logoutput => true
     }


### PR DESCRIPTION
For some projects, we need more than just dependencies installation like compiling static assets. This PR adds support for those projects by allowing passing custom commands.